### PR TITLE
Sort meeting list by day, then time, then city.

### DIFF
--- a/12-step-meeting-pdf.php
+++ b/12-step-meeting-pdf.php
@@ -85,6 +85,17 @@
   // $all_options = get_option('tsml_types_in_use');
   // write_log($all_options);
 
+     // NEW SORT START
+     // Ted Price. 7 JAN 2022
+     // At request of Rich M, we sort by day -> time -> city
+     array_multisort(
+       array_column($meetings, 'day'),  SORT_ASC,
+       array_column($meetings, 'time'), SORT_ASC,
+       array_column($meetings, 'city'), SORT_ASC,
+       $meetings
+     );
+     // NEW SORT END
+
 	$mymeetings = array();
 	foreach ($meetings as $meeting) {
 


### PR DESCRIPTION
Using the updated 12-step-meeting-list code that passes the `city` in the meeting object, this code will sort the meetings list by day (Sunday first), then time, then city.